### PR TITLE
Set type_field when dumping results in an otherwise empty dict

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                                       @PotomacInnovation/owners-data-engineering
+*                                       @PotomacInnovation/data-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*                                       @PotomacInnovation/owners-data-engineering

--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -101,7 +101,7 @@ class OneOfSchema(Schema):
         result = schema.dump(
             obj, many=False, update_fields=update_fields, **kwargs
         )
-        if result.data:
+        if result.data is not None:
             result.data[self.type_field] = obj_type
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
     name='marshmallow-oneofschema',
-    version='1.0.5',
+    version='1.0.6',
     description='Marshmallow multiplexing schema',
     long_description=read('README.rst'),
     author='Maxim Kulkin',

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -416,3 +416,36 @@ class TestOneOfSchema:
         unmarshalled = schema.load(marshalled.data, many=True)
         assert data == unmarshalled.data
         assert {} == unmarshalled.errors
+
+    def test_empty_dict_serialization(self):
+        class OptionalValue:
+            def __init__(self, value=None):
+                if value is not None:
+                    self.value = value
+
+        class OptionalValueSchema(m.Schema):
+            value = f.String()
+            @m.post_load
+            def make_optional_value(self, data):
+                return OptionalValue(**data)
+
+        class OptionalKey:
+            def __init__(self, key=None):
+                if key is not None:
+                    self.key = key
+
+        class OptionalKeySchema(m.Schema):
+            key = f.String()
+            @m.post_load
+            def make_optional_key(self, data):
+                return OptionalKey(**data)
+
+        class OptionalOneOfSchema(OneOfSchema):
+            type_schemas = {
+                'OptionalValue': OptionalValueSchema,
+                'OptionalKey': OptionalKeySchema,
+            }
+
+        ooos = OptionalOneOfSchema()
+        s = ooos.dump(OptionalValue())
+        assert type(ooos.load(s.data).data) == OptionalValue

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -425,6 +425,7 @@ class TestOneOfSchema:
 
         class OptionalValueSchema(m.Schema):
             value = f.String()
+
             @m.post_load
             def make_optional_value(self, data):
                 return OptionalValue(**data)
@@ -436,6 +437,7 @@ class TestOneOfSchema:
 
         class OptionalKeySchema(m.Schema):
             key = f.String()
+
             @m.post_load
             def make_optional_key(self, data):
                 return OptionalKey(**data)

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -450,4 +450,4 @@ class TestOneOfSchema:
 
         ooos = OptionalOneOfSchema()
         s = ooos.dump(OptionalValue())
-        assert type(ooos.load(s.data).data) == OptionalValue
+        assert isinstance(ooos.load(s.data).data, OptionalValue)


### PR DESCRIPTION
Schemas with multiple optional parameters may correctly serialize to an empty dict. Previously, the type would not be set on these, resulting in a serialization which cannot be deserialized by the Schema that produced it.