### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 python:
   - "3.6"
   - "3.5"
-  - "3.4"
   - "2.7"
   - "pypy"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,pypy
+envlist=py27,py35,py36,py37,pypy
 [testenv]
 deps=
   -rrequirements.txt


### PR DESCRIPTION
marshmallow and other associated libs have already dropped support
for 3.4.

See marshmallow-code/marshmallow#804:

> 3.4 is over 4 years old, and 3.7 is around the corner.
> Let's move forward.