### PR TITLE
Add configuration option to nest schema inside the "type" dict

### DIFF
--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -56,8 +56,8 @@ class OneOfSchema(Schema):
     """
     type_field = 'type'
     type_field_remove = True
-    nest_result = False
-    type_schemas = []
+    nest_result = None
+    type_schemas = None
 
     def get_obj_type(self, obj):
         """Returns name of object schema"""
@@ -112,7 +112,7 @@ class OneOfSchema(Schema):
             obj, many=False, **kwargs
         )
         if self.nest_result:
-            result = {'value': result}
+            result = {self._get_nest_result_value(): result}
         if result is not None:
             result[self.type_field] = obj_type
         return result
@@ -162,8 +162,8 @@ class OneOfSchema(Schema):
         if self.type_field in data and self.type_field_remove:
             data.pop(self.type_field)
 
-        if self.nest_result and data['value'] is not None:
-            data = data['value']
+        if self.nest_result is not None:
+            data = data.get(self._get_nest_result_value())
 
         if not data_type:
             raise ValidationError({
@@ -196,3 +196,9 @@ class OneOfSchema(Schema):
         except ValidationError as ve:
             return ve.messages
         return {}
+
+    def _get_nest_result_value(self):
+        if isinstance(self.nest_result, str):
+            return self.nest_result
+        else:
+            return 'value'

--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -162,7 +162,7 @@ class OneOfSchema(Schema):
         if self.type_field in data and self.type_field_remove:
             data.pop(self.type_field)
 
-        if self.nest_result is not None:
+        if self.nest_result:
             data = data.get(self._get_nest_result_value())
 
         if not data_type:

--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -56,6 +56,7 @@ class OneOfSchema(Schema):
     """
     type_field = 'type'
     type_field_remove = True
+    nest_result = False
     type_schemas = []
 
     def get_obj_type(self, obj):
@@ -110,6 +111,8 @@ class OneOfSchema(Schema):
         result = schema.dump(
             obj, many=False, **kwargs
         )
+        if self.nest_result:
+            result = {'value': result}
         if result is not None:
             result[self.type_field] = obj_type
         return result
@@ -158,6 +161,9 @@ class OneOfSchema(Schema):
         data_type = data.get(self.type_field)
         if self.type_field in data and self.type_field_remove:
             data.pop(self.type_field)
+
+        if self.nest_result and data['value'] is not None:
+            data = data['value']
 
         if not data_type:
             raise ValidationError({

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -498,3 +498,11 @@ class TestOneOfSchemaNested:
             {'type': 'Bar', 'value': {'value': 123}},
         ])
         assert Foo('hello world!'), Bar(123) == result
+
+    def test_load_no_value(self):
+        try:
+            MyNestedSchema().load({'type': 'Foo'})
+        except m.ValidationError:
+            pass
+        else:
+            assert False, 'expected a ValidationError'


### PR DESCRIPTION
You don't have to worry about `"type"` field collisions on the schemas if you nest the resulting schema object inside the dictionary one level.

I did a simple implementation just to show how it looks.

Also, I changed the default value for `type_schemas` to be `None`. The code expects it to be a `dict` and having mutable objects as class properties is generally unsafe and makes it confusing to read.