### PR TITLE
only adding type_field to dump result, if type_field_remove is not true

### DIFF
--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -105,7 +105,7 @@ class OneOfSchema(Schema):
         schema.context.update(getattr(self, "context", {}))
 
         result = schema.dump(obj, many=False, **kwargs)
-        if result is not None:
+        if result is not None and not self.type_field_remove:
             result[self.type_field] = obj_type
         return result
 


### PR DESCRIPTION
This merge request changes the _load-function so that the type-field is only added to the dumped output when type_field_remove is set to False

Solves [issue #126](https://github.com/marshmallow-code/marshmallow-oneofschema/issues/126) 