### PR TITLE
Allow custom type detection on load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,14 @@ Changelog
 3.0.0 (unreleased)
 ++++++++++++++++++
 
+Deprecations/Removals:
+
 - Only support Python>=3.6 and marshmallow>=3.0.0.
+
+Features:
+
+- Add ``get_data_type`` method to OneOfSchemas, allowing schemas to define
+  a custom method for determining the type string (PR #128).
 
 2.1.0 (2020-10-05)
 ++++++++++++++++++

--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -60,8 +60,17 @@ class OneOfSchema(Schema):
     type_schemas = {}
 
     def get_obj_type(self, obj):
-        """Returns name of object schema"""
+        """Returns name of the schema during dump() calls, given the object
+        being dumped."""
         return obj.__class__.__name__
+
+    def get_data_type(self, data):
+        """Returns name of the schema during load() calls, given the data being
+        loaded. Defaults to looking up `type_field` in the data."""
+        data_type = data.get(self.type_field)
+        if self.type_field in data and self.type_field_remove:
+            data.pop(self.type_field)
+        return data_type
 
     def dump(self, obj, *, many=None, **kwargs):
         errors = {}
@@ -149,10 +158,7 @@ class OneOfSchema(Schema):
 
         data = dict(data)
         unknown = unknown or self.unknown
-
-        data_type = data.get(self.type_field)
-        if self.type_field in data and self.type_field_remove:
-            data.pop(self.type_field)
+        data_type = self.get_data_type(data)
 
         if not data_type:
             raise ValidationError(

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -410,3 +410,29 @@ class TestOneOfSchema:
 
         unmarshalled = schema.load(marshalled, many=True)
         assert data == unmarshalled
+
+    def test_using_custom_data_type_func(self):
+        # test that you can use the method `get_data_type` to override the
+        # detection of `type` values on data loading
+
+        class FooSchema(m.Schema):
+            value = f.String()
+
+        class BarSchema(m.Schema):
+            value = f.Integer()
+            type = f.String()
+
+        class CustomDataTypeSchema(OneOfSchema):
+            type_schemas = {"foo": FooSchema, "bar": BarSchema}
+
+            def get_data_type(self, data):
+                # if `type` is not present or has a value of `None`, type is
+                # `foo` -- otherwise it's `bar`
+                if data.get("type") is None:
+                    return "foo"
+                return "bar"
+
+        schema = CustomDataTypeSchema()
+        source_data = [{"value": "hello"}, {"type": "blahblahblah", "value": 111}]
+        loaded_data = schema.load(source_data, many=True)
+        assert source_data == loaded_data


### PR DESCRIPTION
This adds get_data_type() as a way of specializing the way that the type is detected during loading. This correlates with `get_obj_type`, just with data moving in the opposite direction (load vs dump).

This makes it possible to specify a OneOfSchema with more "bespoke" ways of detecting the data's type than just checking a single string field.

It's easy to specify a valid OneOf case in OpenAPI or similar where there is no specific field which determines the type of the data. For example, you might have different schemas depending on whether or not a specific field is present at all -- this is the scenario used in the testsuite for testing.
(It's also the case that I ran into while writing schemas for an API that made me want this hook.)

---

I'll add a commit with a changelog entry as soon as the PR is open, so that a number is assigned.