### PR TITLE
Relax type annotation for type_schemas

### DIFF
--- a/src/marshmallow_oneofschema/one_of_schema.py
+++ b/src/marshmallow_oneofschema/one_of_schema.py
@@ -59,7 +59,7 @@ class OneOfSchema(Schema):
 
     type_field = "type"
     type_field_remove = True
-    type_schemas: typing.Dict[str, typing.Type[Schema]] = {}
+    type_schemas: typing.Mapping[str, typing.Union[typing.Type[Schema], Schema]] = {}
 
     def get_obj_type(self, obj):
         """Returns name of the schema during dump() calls, given the object


### PR DESCRIPTION
The type_schemas member is used as a mapping of either a schema class or schema instance. Relax the type annotation of that member to be either.

Resolves #184