### PR TITLE
Fix valid_data being a list when many=False

### DIFF
--- a/src/marshmallow_oneofschema/one_of_schema.py
+++ b/src/marshmallow_oneofschema/one_of_schema.py
@@ -129,13 +129,12 @@ class OneOfSchema(Schema):
             partial = self.partial
         if not many:
             try:
-                result = result_data = self._load(
+                result_data = self._load(
                     data, partial=partial, unknown=unknown, **kwargs
                 )
-                #  result_data.append(result)
             except ValidationError as error:
                 result_errors = error.normalized_messages()
-                result_data.append(error.valid_data)
+                result_data = error.valid_data
         else:
             for idx, item in enumerate(data):
                 try:

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -234,6 +234,24 @@ class TestOneOfSchema:
             3: {"value": ["Not a valid integer."]},
         } == exc_info.value.messages
 
+    def test_load_error_valid_data(self):
+        with pytest.raises(m.ValidationError) as exc_info:
+            MySchema().load({"type": "Foo", "value": 123})
+
+        assert exc_info.value.valid_data == {}
+
+    def test_load_error_valid_data_many(self):
+        with pytest.raises(m.ValidationError) as exc_info:
+            MySchema().load(
+                [
+                    {"type": "Foo", "value": 123},
+                    {"type": "Foo", "value": "hello"},
+                ],
+                many=True,
+            )
+
+        assert exc_info.value.valid_data == [{}, Foo("hello")]
+
     def test_load_partial_specific(self):
         result = MySchema().load({"type": "Foo"}, partial=("value", "value2"))
         assert Foo() == result


### PR DESCRIPTION
`ValidationError.valid_data` is always a list, even if `many=False`.

I've added a test for both cases, one of which fails without the change I made.