### PR TITLE
Update to handle schema.context on marshmallow v4 and allow v4 in package dependencies

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - { name: "3.9", python: "3.9", tox: py39-marshmallow3 }
           - { name: "3.13", python: "3.13", tox: py313-marshmallow3 }
+          - { name: "3.9", python: "3.9", tox: py39-marshmallow4 }
+          - { name: "3.13", python: "3.13", tox: py313-marshmallow4 }
           - { name: "lowest", python: "3.9", tox: py39-lowest }
           - { name: "dev", python: "3.13", tox: py313-marshmallowdev }
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.9"
-dependencies = ["marshmallow>=3.0.0,<4.0.0"]
+dependencies = ["marshmallow>=3.0.0,<5.0.0"]
 
 [project.urls]
 Issues = "https://github.com/marshmallow-code/marshmallow-oneofschema/issues"

--- a/src/marshmallow_oneofschema/one_of_schema.py
+++ b/src/marshmallow_oneofschema/one_of_schema.py
@@ -115,7 +115,9 @@ class OneOfSchema(Schema):
 
         schema = type_schema if isinstance(type_schema, Schema) else type_schema()
 
-        schema.context.update(getattr(self, "context", {}))
+        # marshmallow 3 compatibility -- handle updates to the schema.context
+        if hasattr(schema, "context"):
+            schema.context.update(getattr(self, "context", {}))
 
         result = schema.dump(obj, many=False, **kwargs)
         if result is not None:
@@ -183,7 +185,9 @@ class OneOfSchema(Schema):
 
         schema = type_schema if isinstance(type_schema, Schema) else type_schema()
 
-        schema.context.update(getattr(self, "context", {}))
+        # marshmallow 3 compatibility -- handle updates to the schema.context
+        if hasattr(schema, "context"):
+            schema.context.update(getattr(self, "context", {}))
 
         return schema.load(data, many=False, partial=partial, unknown=unknown, **kwargs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
     lint
     py{39,310,311,312,313}-marshmallow3
+    py{39,313}-marshmallow4
     py313-marshmallowdev
     py39-lowest
 
@@ -9,6 +10,7 @@ envlist=
 extras = tests
 deps =
     marshmallow3: marshmallow>=3.0.0,<4.0.0
+    marshmallow4: marshmallow>=4.0.0,<5.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
     lowest: marshmallow==3.0.0
 commands = pytest {posargs}


### PR DESCRIPTION
- Update the `schema.context` handling to be gated on `hasattr()`
- Update CI and tox matrices to test explicitly on ma4
- Update the package dependencies to allow ma4

---

I'd really like to get a v4-compatible release out, as it blocks my ability to test upgrades to marshmallow v4 in some projects.
